### PR TITLE
Fix invalid IP Address header and fix GA fields

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,9 +31,10 @@ app.get('*', function (req, res) {
         user_agent = req.headers['user-agent'] || '',
         params = {
             ap: config.projectPreffix,
-            dl: referal,
+            dr: referal,
             v: config.apiVersion,
-            t: 'pageview'
+            t: 'pageview',
+            ua: user_agent
         },
         url = ur.parse(req.url, true).pathname.substring(1),
         clientid;
@@ -57,10 +58,6 @@ app.get('*', function (req, res) {
         var path = config.hostname + config.path;
 
         request.post(path, {
-            headers: {
-                'User-Agent': user_agent,
-                'IP Address': req.ip
-            },
             qs: params
         });
 


### PR DESCRIPTION
- Поправил невалидный хедер `IP Address`, там нельзя ставить пробелы
- Поправил поля для аналитики, кажется, они действительно были не те, правильные можно глянуть тут https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters