### PR TITLE
Return dl field, user-agent header

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,11 +30,14 @@ app.get('*', function (req, res) {
     var referal = req.headers.referer || '',
         user_agent = req.headers['user-agent'] || '',
         params = {
-            ap: config.projectPreffix,
-            dr: referal,
+            // Обязательный параметр для pageview
+            dl: referal,
+
             v: config.apiVersion,
             t: 'pageview',
-            ua: user_agent
+            ua: user_agent,
+
+            uip: req.ip,
         },
         url = ur.parse(req.url, true).pathname.substring(1),
         clientid;
@@ -58,6 +61,9 @@ app.get('*', function (req, res) {
         var path = config.hostname + config.path;
 
         request.post(path, {
+            headers: {
+                'User-Agent': user_agent
+            },
             qs: params
         });
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "apiVersion": 1,
-    "hostname": "http://www.google-analytics.com",
+    "hostname": "https://www.google-analytics.com",
     "path": "/collect",
     "projects": [
         {


### PR DESCRIPTION
- Удалил параметр `ap`, он всегда отсылался как `undefined`, и в [списке](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters?hl=ru) я его вообще не нашел.
- Вернул параметр `dl` вместо `dr`, все таки нужен он, а не реферер.
- Добавил параметр `uip`, кажется, это то, что нам нужно, чтобы учитывать ip адреса пользователя
- Поменял отсылку запросов на `https`, в [доке](https://developers.google.com/analytics/devguides/collection/protocol/v1/reference?hl=ru) явно сказано, что нужен `HTTPS`
- Вернул user-agent в хедер, из доки непонятно нужен ли он или нет, но лишним не будет